### PR TITLE
Fix `tab_control` initialization issue in `PulseServer` class

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,7 +44,7 @@ class PulseServer:
 
 
         ## Frame Management
-        self.tab_control = ttk.Notebook(root)
+        self.tab_control = ttk.Notebook(self.master)
 
         self.pulse_audio_server = ttk.Frame(self.tab_control, style='new.TFrame')
         self.pulse_audio_mic = ttk.Frame(self.tab_control,style='new.TFrame')


### PR DESCRIPTION
This fix ensures that `tab_control` is initialized with `self.master`
instead `root` object. This improves the stability of the PulseServer
class.
